### PR TITLE
Add linking external libraries to the documentation

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -87,7 +87,7 @@ By default, KLEE will report an error if the assumed condition is infeasible. Th
 
 ## Linking External Libraries
 
-Defintions of undefined functions are taken from files given using the option
+Definitions of undefined functions are taken from files given using the option
 `-link-llvm-lib`.
 
 If some functions in the input file are defined in an external LLVM IR file, an

--- a/docs/options.md
+++ b/docs/options.md
@@ -84,3 +84,12 @@ To change the entry point you can use the option `-entry-point=FUNCTION_NAME`, w
 ## Calls to `klee-assume`
 
 By default, KLEE will report an error if the assumed condition is infeasible. The option `-silent-klee-assume` can be used to sliently terminate the current path exploration in such cases.
+
+## Linking External Libraries
+
+Defintions of undefined functions are taken from files given using the option
+`-link-llvm-lib`.
+
+If some functions in the input file are defined in an external LLVM IR file, an
+archive (.a) of LLVM IR files, or a shared object with LLVM IR code, these
+external files can be *linked in* using the option `-link-llvm-lib=LIB_FILENAME`.


### PR DESCRIPTION
Explain a new command-line option to link an external library, as
proposed in https://github.com/klee/klee/pull/346.