### PR TITLE
Updated tutorials with LLVM 3.4

### DIFF
--- a/tutorials/testing-function.md
+++ b/tutorials/testing-function.md
@@ -35,13 +35,15 @@ int main() {
 
 ## Compiling to LLVM bitcode
 
-KLEE operates on LLVM bitcode. To run a program with KLEE, you first compile it to LLVM bitcode using `llvm-gcc --emit-llvm`. Assuming our code is stored in `get_sign.c`, we run:
+KLEE operates on LLVM bitcode. To run a program with KLEE, you first compile it to LLVM bitcode using `clang -emit-llvm`. Assuming our code is stored in `get_sign.c`, we run:
 
 {% highlight bash %}
-$ llvm-gcc --emit-llvm -c -g get_sign.c
+$ clang -emit-llvm -c -g get_sign.c
 {% endhighlight %}
 
 to generate the LLVM bitcode file `get_sign.o`. It is useful to (1) build with `-g` to add debug information to the bitcode file, which we use to generate source line level statistics information, and (2) not use any optimization flags. The code can be optimized later, as KLEE provides the `--optimize` command line option to run the optimizer internally.
+
+**NOTE:** If you have built KLEE with LLVM 2.9, replace `clang` with `llvm-gcc`.
 
 ## Running KLEE
 

--- a/tutorials/testing-regex.md
+++ b/tutorials/testing-regex.md
@@ -15,12 +15,12 @@ We'll start by showing how to build and run the example, and then explain how th
 
 ## Building the example
 
-The first step is to compile the source code using a compiler which can generate object files in LLVM bitcode format. Here we use llvm-gcc, but [Clang](http://clang.llvm.org) works just as well!
+The first step is to compile the source code using a compiler which can generate object files in LLVM bitcode format. Here we use [Clang](http://clang.llvm.org) but if you have built KLEE with LLVM 2.9, you should use `llvm-gcc`.
 
 From within the `examples/regexp` directory:
 
 {% highlight bash %}
-$ llvm-gcc -I ../../include -emit-llvm -c -g Regexp.c
+$ clang -I ../../include -emit-llvm -c -g Regexp.c
 {% endhighlight %}
 
 which should create a Regexp.o file in LLVM bitcode format. The `-I` argument is used so that the compiler can find [`klee/klee.h`](http://t1.minormatter.com/~ddunbar/klee-doxygen/klee_8h-source.html), which contains definitions for the intrinsic functions used to interact with the KLEE virtual machine. `-c` is used because we only want to compile the code to an object file (not a native executable), and finally `-g` causes additional debug information to be stored in the object file, which KLEE will use to determine source line number information.


### PR DESCRIPTION
Updated compilation steps in tutorials from llvm-gcc to clang.
Added notes in the text to point users to use llvm-gcc only with LLVM 2.9