### PR TITLE
docs/options: add exiting klee

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -164,3 +164,34 @@ To change this behaviour, following options are provided:
 * `--allocate-determ-start-addres`     - Controls the required start address of the pre-allocated memory. This address has to be page aligned. If null is provided, the memory is mapped to an arbitrary address.
 * `--return-null-on-zero-malloc`       - Controls if a NULL pointer should be returned in case the size argument is zero (*default=off*)
 * `--red-zone-space`                   - Controls the space kept unused between two adjacent allocations in byte (*default=10*)
+
+## Making KLEE Exit on Events
+
+KLEE does not exit if a bug is found in the analyzed application by default. On
+the other hand, KLEE implicitly exits on some failures. This behaviour can be
+changed by the following options:
+
+* `-exit-on-error`                     - Exit on the first arbitrary error.
+* `-exit-on-error-type=TYPE`           - Exit on the first error of type `TYPE`. This parameter can be repeated to exit after more types. `TYPE` can one of the following:
+  - `=Abort`       - The program crashed
+  - `=Assert`      - An assertion was hit
+  - `=Exec`        - Trying to execute an unexpected instruction
+  - `=External`    - External objects referenced
+  - `=Free`        - Freeing invalid memory
+  - `=Model`       - Memory model limit hit
+  - `=Overflow`    - An overflow occurred
+  - `=Ptr`         - Pointer error
+  - `=ReadOnly`    - Write to read-only memory
+  - `=ReportError` - `klee_report_error` called
+  - `=User`        - Wrong `klee_*` functions invocation
+  - `=Unhandled`   - Unhandled instruction hit
+
+* `-ignore-solver-failures`            - Do not exit upon solver failure.
+
+Examples:
+{% highlight bash %}
+klee -exit-on-error input.bc
+{% endhighlight %}
+{% highlight bash %}
+klee -exit-on-error-type=Assert -exit-on-error-type=Ptr input.bc
+{% endhighlight %}


### PR DESCRIPTION
I was unable to test this as I get:

```
$ bundle exec jekyll build
Configuration file: /home/latest/repos/klee.github.io/_config.yml
            Source: /home/latest/repos/klee.github.io
       Destination: /home/latest/repos/klee.github.io/_site
 Incremental build: disabled. Enable with --incremental
      Generating... 
     Build Warning: Layout 'post' requested in gems/ruby/2.3.0/gems/jekyll-3.1.6/lib/site_template/_posts/0000-00-00-welcome-to-jekyll.markdown.erb does not exist.
  Liquid Exception: Included file '_includes/icon-github.html' not found in gems/ruby/2.3.0/gems/jekyll-3.1.6/lib/site_template/about.md
jekyll 3.1.6 | Error:  Included file '_includes/icon-github.html' not found
```
