### PR TITLE
Klee CMake instructions

### DIFF
--- a/build-llvm29.md
+++ b/build-llvm29.md
@@ -86,8 +86,8 @@ If you want to build KLEE with LLVM 3.4 (recommended), [click here]({{site.baseu
 8. **Run the regression suite to verify your build:**
 
    ```bash
-   $ make check  
-   $ make unittests  
+   $ make systemtests
+   $ make unittests
    ```
 
    **NOTE:** For testing real applications (e.g. Coreutils), you may need to increase your system's open file limit (ulimit -n). Something between 10000 and 999999 should work. In most cases, the hard limit will have to be increased first, so it is best to directly edit the `/etc/security/limits.conf` file.<br/><br/>

--- a/build-llvm29.md
+++ b/build-llvm29.md
@@ -32,7 +32,7 @@ If you want to build KLEE with LLVM 3.4 (recommended), [click here]({{site.baseu
 
 2. **Build LLVM 2.9:** KLEE is built on top of [LLVM](http://llvm.org); the first steps are to get a working LLVM installation. See [Getting Started with the LLVM System](http://llvm.org/docs/GettingStarted.html) for more information.
 
-   **NOTE:** The only LLVM version currently supported by KLEE is **LLVM 2.9**. KLEE is currently tested on **Linux x86-64**, and might break on x86-32. KLEE will **not** compile with LLVM versions prior to 2.9, and there is only experimental support for LLVM 3.4. 
+   **NOTE:** KLEE is currently tested on **Linux x86-64**, and might break on x86-32. KLEE will **not** compile with LLVM versions prior to 2.9.
 
    1. Install llvm-gcc:
       * Download and install the LLVM 2.9 release of llvm-gcc from  [here](http://llvm.org/releases/download.html#2.9). On an x86-64 Linux platform you are going to need the archive  [LLVM-GCC 4.2 Front End Binaries for Linux x86-64](http://llvm.org/releases/2.9/llvm-gcc4.2-2.9-x86_64-linux.tar.bz2). 

--- a/build-llvm34-autoconf.md
+++ b/build-llvm34-autoconf.md
@@ -1,0 +1,142 @@
+---
+layout: default
+title: Building KLEE
+subtitle: with LLVM 3.4 and Autoconf build system
+slug: build-llvm34-autoconf
+---
+
+{% include version_warning.md %}
+
+The current procedure for building KLEE with LLVM 3.4 (recommended) using
+KLEE's older Autoconf/Makefile build system is outlined below.
+If you want to build KLEE with LLVM 2.9, [click here]({{site.baseurl}}/build-llvm29).
+
+1. **Install dependencies:** KLEE requires all the dependencies of LLVM, which are discussed [here](http://llvm.org/docs/GettingStarted.html#requirements). In particular, you should install the following programs and libraries, listed below as Ubuntu packages:  
+
+   ```bash
+   $ sudo apt-get install build-essential curl libcap-dev git cmake libncurses5-dev python-minimal python-pip unzip
+   ```
+
+   You will need gcc/g++ 4.8 or later installed on your system. For Ubuntu 12.04 and 13.04, you can follow the instructions [here](http://ubuntuhandbook.org/index.php/2013/08/install-gcc-4-8-via-ppa-in-ubuntu-12-04-13-04/).   
+
+   **(Optional) Build KLEE with TCMalloc support:** By default, KLEE uses malloc_info() to observe and to restrict its memory usage. Due to limitations of malloc_info(), the maximum limit is set to 2 GB. To support bigger limits, KLEE can use TCMalloc as an alternative allocator. It is thus necessary to install TCMalloc:
+
+   ```bash
+   $ sudo apt-get install libtcmalloc-minimal4 libgoogle-perftools-dev
+   ```
+
+2. **Install LLVM 3.4:** KLEE is built on top of [LLVM](http://llvm.org); the first steps are to get a working LLVM installation. See [Getting Started with the LLVM System](http://llvm.org/docs/GettingStarted.html) for more information.
+
+   _**NOTE:** Currently, KLEE has only experimental support for **LLVM 3.4**. The only stable LLVM version for KLEE is **LLVM 2.9**. KLEE is currently tested on **Linux x86-64**, and might break on x86-32. KLEE will **not** compile with LLVM versions prior to 2.9._
+
+   If you are using a recent Ubuntu (≥ 12.04, e.g. 14.04 LTS) or Debian, we recommend you to use the LLVM packages provided by LLVM itself. Use [LLVM Package Repository](http://llvm.org/apt/) to add the appropriate line to your `/etc/apt/sources.list`. As an example, for Ubuntu 14.04, the following lines should be added:  
+
+   ```bash
+   deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.4 main  
+   deb-src http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.4 main
+   ```
+
+   Then add the repository key and install the 3.4 packages:  
+
+   ```bash
+   $ wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key|sudo apt-key add -  
+   $ sudo apt-get update  
+   $ sudo apt-get install clang-3.4 llvm-3.4 llvm-3.4-dev llvm-3.4-tools  
+   ```
+
+   Finally, make sure llvm-config is in your path:   
+
+   ```bash
+   $ sudo ln -sf /usr/bin/llvm-config-3.4 /usr/bin/llvm-config
+   ```
+
+   That's it for LLVM. If you want to install it manually, please refer to the official [LLVM Getting Started documentation](http://www.llvm.org/docs/GettingStarted.html).<br/><br/>  
+
+3. **Build STP:** KLEE is based on the STP constraint solver, you can find the instructions [here]({{site.baseurl}}/build-stp).
+
+4. **(Optional) Build uclibc and the POSIX environment model:** By default, KLEE works on closed programs (programs that don't use any external code such as C library functions). However, if you want to use KLEE to run real programs you will want to enable the KLEE POSIX runtime, which is built on top of the [uClibc](http://uclibc.org) C library.  
+
+   ```bash
+   $ git clone https://github.com/klee/klee-uclibc.git  
+   $ cd klee-uclibc  
+   $ ./configure --make-llvm-lib  
+   $ make -j2  
+   $ cd .. 
+   ```
+
+   **NOTE:** If you are on a different target (i.e., not i386 or x64), you will need to run make config and select the correct target. The defaults for the other uClibc configuration variables should be fine.<br/><br/>  
+
+5. **(Optional) Build libgtest:**
+
+   Build Google test libraries for unit tests. We do a manual build, because the libgtest-dev package (version 1.6) installed through apt does not work for us.  
+
+   ```bash
+   $ curl -OL https://googletest.googlecode.com/files/gtest-1.7.0.zip  
+   $ unzip gtest-1.7.0.zip  
+   $ cd gtest-1.7.0  
+   $ cmake .  
+   $ make  
+   $ cd ..
+   ```
+
+6. **Get KLEE source:**  
+
+   ```bash
+   $ git clone https://github.com/klee/klee.git
+   ```
+
+7. **Configure KLEE:** From the KLEE source directory, run:  
+
+   ```bash
+   $ ./configure --with-stp=/full/path/to/stp/build --with-uclibc=/full/path/to/klee-uclibc --enable-posix-runtime
+   ```
+
+   **NOTE:** If LLVM is not found or you have multiple LLVM versions installed, you can add `--with-llvmsrc=/usr/lib/llvm-3.4/build --with-llvmobj=/usr/lib/llvm-3.4/build --with-llvmcc=/usr/bin/clang-3.4 --with-llvmcxx=/usr/bin/clang++-3.4`.  
+If you skipped step 4, simply remove the `--with-uclibc` and `--enable-posix-runtime` options.<br/><br/>  
+
+8. **Build KLEE:**  
+
+   ```bash
+   $ make  
+   ```
+   <!-- make DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 ENABLE_SHARED=0 -j2-->
+
+   **NOTE:** You can add `/full/path/to/klee/build/Release/bin` to your path.<br/><br/>
+
+
+9. **Run the main regression test suite to verify your build:**
+   
+   ```bash
+   $ make test
+   ```
+   
+   If you want to invoke `lit` manually use:
+   ```bash
+   $ /usr/lib/llvm-3.4/build/utils/lit/lit.py test/
+   ```
+   
+   This way you can run individual tests or subsets of the suite:
+   ```bash
+   $ /usr/lib/llvm-3.4/build/utils/lit/lit.py test/regression
+   ```
+   
+10. **(Optional) Run the unit tests:**
+
+    If you did not install the LLVM upstream or Debian packages,
+    install the LLVM unit tests makefile:
+   
+    ```bash
+    $ sudo mkdir -p /usr/lib/llvm-3.4/build/unittests/  
+    $ sudo curl -L http://llvm.org/svn/llvm-project/llvm/branches/release_34/unittests/Makefile.unittest -o /usr/lib/llvm-3.4/build/unittests/Makefile.unittest  
+    ```
+
+    Run KLEE unit tests:
+
+    ```bash
+    $ make CPPFLAGS=-I/full/path/to/gtest-1.7.0/include LDFLAGS=-L/full/path/to/gtest-1.7.0 unittests
+    ```
+11. **You're ready to go! Check the [Tutorials]({{site.baseurl}}/tutorials) page to try KLEE.**
+
+<!--    **NOTE:** The flags (DISABLE_ASSERTIONS, ENABLE_OPTIMIZED, ENABLE_SHARED) have to be the same as the ones used for building KLEE. -->
+
+**NOTE:** For testing real applications (e.g. Coreutils), you may need to increase your system's open file limit (ulimit -n). Something between 10000 and 999999 should work. In most cases, the hard limit will have to be increased first, so it is best to directly edit the `/etc/security/limits.conf` file.<br/><br/>

--- a/build-llvm34-autoconf.md
+++ b/build-llvm34-autoconf.md
@@ -107,7 +107,7 @@ If you skipped step 4, simply remove the `--with-uclibc` and `--enable-posix-run
 9. **Run the main regression test suite to verify your build:**
    
    ```bash
-   $ make test
+   $ make systemtests
    ```
    
    If you want to invoke `lit` manually use:

--- a/build-llvm34-autoconf.md
+++ b/build-llvm34-autoconf.md
@@ -27,7 +27,7 @@ If you want to build KLEE with LLVM 2.9, [click here]({{site.baseurl}}/build-llv
 
 2. **Install LLVM 3.4:** KLEE is built on top of [LLVM](http://llvm.org); the first steps are to get a working LLVM installation. See [Getting Started with the LLVM System](http://llvm.org/docs/GettingStarted.html) for more information.
 
-   _**NOTE:** Currently, KLEE has only experimental support for **LLVM 3.4**. The only stable LLVM version for KLEE is **LLVM 2.9**. KLEE is currently tested on **Linux x86-64**, and might break on x86-32. KLEE will **not** compile with LLVM versions prior to 2.9._
+   **NOTE:** KLEE is currently tested on **Linux x86-64**, and might break on x86-32.
 
    If you are using a recent Ubuntu (≥ 12.04, e.g. 14.04 LTS) or Debian, we recommend you to use the LLVM packages provided by LLVM itself. Use [LLVM Package Repository](http://llvm.org/apt/) to add the appropriate line to your `/etc/apt/sources.list`. As an example, for Ubuntu 14.04, the following lines should be added:  
 

--- a/build-llvm34.md
+++ b/build-llvm34.md
@@ -24,7 +24,7 @@ If you want to build KLEE with LLVM 2.9, [click here]({{site.baseurl}}/build-llv
 
 2. **Install LLVM 3.4:** KLEE is built on top of [LLVM](http://llvm.org); the first steps are to get a working LLVM installation. See [Getting Started with the LLVM System](http://llvm.org/docs/GettingStarted.html) for more information.
 
-   _**NOTE:** Currently, KLEE has only experimental support for **LLVM 3.4**. The only stable LLVM version for KLEE is **LLVM 2.9**. KLEE is currently tested on **Linux x86-64**, and might break on x86-32. KLEE will **not** compile with LLVM versions prior to 2.9._
+   **NOTE:** KLEE is currently tested on **Linux x86-64**, and might break on x86-32.
 
    If you are using a recent Ubuntu (≥ 12.04 and ≤ 15.10, e.g. 14.04 LTS) or Debian, we recommend you to use the LLVM packages provided by LLVM itself. Use [LLVM Package Repository](http://llvm.org/apt/) to add the appropriate line to your `/etc/apt/sources.list`. As an example, for Ubuntu 14.04, the following lines should be added:  
 

--- a/build-llvm34.md
+++ b/build-llvm34.md
@@ -18,13 +18,6 @@ If you want to build KLEE with LLVM 2.9, [click here]({{site.baseurl}}/build-llv
 
    You will need gcc/g++ 4.8 or later installed on your system. For Ubuntu 12.04 and 13.04, you can follow the instructions [here](http://ubuntuhandbook.org/index.php/2013/08/install-gcc-4-8-via-ppa-in-ubuntu-12-04-13-04/).   
 
-   On some architectures, you might also need to set the following environment variables (best to put them in a config file like **.bashrc**):  
-
-   ```bash
-   $ export C_INCLUDE_PATH=/usr/include/x86_64-linux-gnu  
-   $ export CPLUS_INCLUDE_PATH=/usr/include/x86_64-linux-gnu
-   ```
-
    **(Optional) Build KLEE with TCMalloc support:** By default, KLEE uses malloc_info() to observe and to restrict its memory usage. Due to limitations of malloc_info(), the maximum limit is set to 2 GB. To support bigger limits, KLEE can use TCMalloc as an alternative allocator. It is thus necessary to install TCMalloc:
 
    ```bash

--- a/build-llvm34.md
+++ b/build-llvm34.md
@@ -13,7 +13,7 @@ If you want to build KLEE with LLVM 2.9, [click here]({{site.baseurl}}/build-llv
 1. **Install dependencies:** KLEE requires all the dependencies of LLVM, which are discussed [here](http://llvm.org/docs/GettingStarted.html#requirements). In particular, you should install the following programs and libraries, listed below as Ubuntu packages:  
 
    ```bash
-   $ sudo apt-get install build-essential curl bison flex bc libcap-dev git cmake libboost-all-dev libncurses5-dev python-minimal python-pip unzip
+   $ sudo apt-get install build-essential curl libcap-dev git cmake libncurses5-dev python-minimal python-pip unzip
    ```
 
    You will need gcc/g++ 4.8 or later installed on your system. For Ubuntu 12.04 and 13.04, you can follow the instructions [here](http://ubuntuhandbook.org/index.php/2013/08/install-gcc-4-8-via-ppa-in-ubuntu-12-04-13-04/).   

--- a/build-stp.md
+++ b/build-stp.md
@@ -10,6 +10,12 @@ The instructions below are for the release 2.1.2. If you would like to use the u
 
 _Please let us know if you have successfully and extensively used KLEE with a more recent version of STP._  
 
+STP has a few external dependencies they are listed below as an install command for Ubuntu 14.04LTS.
+
+```bash
+sudo apt-get install cmake bison flex libboost-all-dev python perl
+```
+
 ```bash
 $ git clone https://github.com/stp/minisat.git
 $ cd minisat
@@ -25,6 +31,7 @@ $ mkdir build
 $ cd build
 ```
 
+<!-- TODO: Once we switch to CMake drop building the static library. Using the shared library works fine when KLEE is built with CMake -->
 Shared STP libraries cause problems for KLEE, so we have to disable them ([see this mailing list thread](https://www.mail-archive.com/klee-dev@imperial.ac.uk/msg01704.html)). The python interface requires shared libraries, so we have to disable that, too.
 
 ```bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,8 +9,9 @@ slug: documentation
 
 
 1. [Using KLEE Docker image]({{site.baseurl}}/docker/): Instructions on how to use the KLEE Docker image.
+1. [Building KLEE (LLVM 3.4)]({{site.baseurl}}/build-llvm34/): Instructions on how to build KLEE from source using LLVM 3.4 and CMake.
+1. [Building KLEE (LLVM 3.4) using Autoconf]({{site.baseurl}}/build-llvm34-autoconf/): Instructions on how to build KLEE from source using LLVM 3.4 and KLEE's older Autoconf/Makefile based build system.
 1. [Building KLEE (LLVM 2.9)]({{site.baseurl}}/build-llvm29/): Instructions on how to build KLEE from source using LLVM 2.9.
-1. [Building KLEE (LLVM 3.4)]({{site.baseurl}}/build-llvm34/): Instructions on how to build KLEE from source using LLVM 3.4.
 1. [Building STP]({{site.baseurl}}/build-stp/): Instructions on how to build STP, KLEE's default constraint solver.
 1. [KLEE Options]({{site.baseurl}}/docs/options/): Overview of KLEE's main command-line options.
 1. [Kleaver Options]({{site.baseurl}}/docs/kleaver-options/): Overview of Kleaver's main command-line options.

--- a/getting-started.md
+++ b/getting-started.md
@@ -9,4 +9,5 @@ There are three ways to get started with KLEE.
 
 * [Use our Docker images]({{site.baseurl}}/docker): this is the fastest way to get started.
 * [Build from source against LLVM 3.4]({{site.baseurl}}/build-llvm34): this is the current recommended version.
+* [Build from source against LLVM 3.4 (using Autoconf)]({{site.baseurl}}/build-llvm34-autoconf): Same as above but using KLEE's older Autoconf/Makefile based build system.
 * [Build from source against LLVM 2.9]({{site.baseurl}}/build-llvm29): this is another version which we are still maintaining.

--- a/index.html
+++ b/index.html
@@ -32,8 +32,8 @@ title: KLEE
           </span>
           <ol class="list-links list-links--secondary">
             <li><a href="{{site.baseurl}}/docker">Use KLEE Docker image</a></li>
-            <li><a href="{{site.baseurl}}/build-llvm29">Building KLEE (LLVM 2.9)</a></li>
             <li><a href="{{site.baseurl}}/build-llvm34">Building KLEE (LLVM 3.4)</a></li>
+            <li><a href="{{site.baseurl}}/build-llvm29">Building KLEE (LLVM 2.9)</a></li>
             <li><a href="{{site.baseurl}}/docs/options/">Command-line options</a></li>
             <li><a href="{{site.baseurl}}/docs/intrinsics/">Intrinsic functions</a></li>
             <li><a href="{{site.baseurl}}/docs/files/">Generated files</a></li>


### PR DESCRIPTION
I don't have any desire to confuse people by giving them an option when using LLVM 3.4 of both build systems. The new build system works in more scenarios (e.g. you can build against an installed LLVM on non Debian distributions) than the old one so this should be preferred as it is more likely to work.