### PR TITLE
Add dot when execute build Dockerfile command

### DIFF
--- a/docker.md
+++ b/docker.md
@@ -46,7 +46,7 @@ If you want to build the Docker image manually instead of pulling the image from
 ```bash
 $ git clone https://github.com/klee/klee.git
 $ cd klee
-$ docker build -t klee/klee
+$ docker build -t klee/klee .
 ```
 
 This will use the contents of the ``Dockerfile`` in the root of the repository to build the Docker image.


### PR DESCRIPTION
KLEE documentation "Building the Docker image locally" section have command syntax error

```
docker build -t klee/klee
```

This command can't build dockerfile

So, I fixed this docker build command.