### PR TITLE
Updated Minisat build instructions

### DIFF
--- a/build-stp.md
+++ b/build-stp.md
@@ -15,7 +15,7 @@ $ git clone https://github.com/stp/minisat.git
 $ cd minisat
 $ mkdir build
 $ cd build
-$ cmake -DSTATICCOMPILE=ON -DCMAKE_INSTALL_PREFIX=/usr/ ../
+$ cmake -DSTATIC_BINARIES=ON -DCMAKE_INSTALL_PREFIX=/usr/ ../
 $ sudo make install
 $ cd ../../
 $ git clone https://github.com/stp/stp.git


### PR DESCRIPTION
The instructions say to use the STATICCOMPILE option, however if you look in the Minisat CMake file (https://github.com/stp/minisat/blob/master/CMakeLists.txt) the option is actually STATIC_BINARIES.