### PR TITLE
Document main solver options + Assignment validating solver

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@ github: [Repository metadata]
 markdown: kramdown
 kramdown:
   input: GFM
-  toc_levels: "1..2"
+  toc_levels: "1..3"
 highlighter: rouge
 permalink: pretty
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,7 @@ slug: documentation
 1. [Building KLEE (LLVM 3.4) using Autoconf]({{site.baseurl}}/build-llvm34-autoconf/): Instructions on how to build KLEE from source using LLVM 3.4 and KLEE's older Autoconf/Makefile based build system.
 1. [Building KLEE (LLVM 2.9)]({{site.baseurl}}/build-llvm29/): Instructions on how to build KLEE from source using LLVM 2.9.
 1. [Building STP]({{site.baseurl}}/build-stp/): Instructions on how to build STP, KLEE's default constraint solver.
+1. [Solver Chain]({{site.baseurl}}/docs/solver-chain/): Overview of the solver chain and related command line arguments.
 1. [KLEE Options]({{site.baseurl}}/docs/options/): Overview of KLEE's main command-line options.
 1. [Kleaver Options]({{site.baseurl}}/docs/kleaver-options/): Overview of Kleaver's main command-line options.
 2. [Intrinsics]({{site.baseurl}}/docs/intrinsics/): Overview of the main KLEE intrinsic functions.

--- a/docs/kleaver-options.md
+++ b/docs/kleaver-options.md
@@ -41,23 +41,13 @@ An input query log may contain independent queries, that is query declarations t
 $ kleaver --clear-array-decls-after-query=true klee-queries.kquery
 {% endhighlight %}
 
-## Solver  
+## Solver
 
-Kleaver can leverage several backend SMT solvers to compute the query:
-
-1.  **STP (Default):** Simple Theorem Prover SMT solver [link](http://stp.github.io)
-2.  **Z3:** The Z3 Theorem Prover [link](https://github.com/Z3Prover/z3)
-3.  **metaSMT:** An Embedded Domain Specific Language for SMT [link](http://www.informatik.uni-bremen.de/agra/eng/metasmt.php)
-
-To select a specific SMT solver, use the `-solver-backend` option provided by Kleaver. For example:
-
-{% highlight bash %}
-$ kleaver --solver-backend=stp query.kquery
-{% endhighlight %}
+Kleaver can leverage several backend SMT solvers to compute the query see [Solver Chain]({{site.baseurl}}/docs/solver-chain/) for details.
 
 ## Query Logging
 
-To log the queries issued by Kleaver to the underlying solver, you can use the same options described for KLEE [here]({{site.baseurl}}/docs/options/#query-logging).
+To log the queries issued by Kleaver to the underlying solver see [Solver Chain]({{site.baseurl}}/docs/solver-chain/) for details.
 
 To select where to store the log, you can use the `-query-log-dir` option. The default value is the current working directory. For example:
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -113,17 +113,7 @@ The default heuristics used by KLEE are `random-path` interleaved with `nurs:cov
 
 ## Query Logging
 
-To log the queries issued by KLEE during symbolic execution, you can use the following options:
-
-1.  `--use-query-log=TYPE:FORMAT`, where:
-    - **TYPE** is either **all** to log all the queries KLEE made during execution before any optimisation (e.g. caching, constraint independence) is performed, or **solver** to log only the queries passed to KLEE's underlying solver. Note that it is possible that some of the unoptimized queries are never executed or are modified before being executed by KLEE's underlying solver.
-    - **FORMAT** is the format in which queries are logged and can be either **kquery** for the [KQuery]({{site.baseurl}}/docs/kquery) format, or **smt2** for the [SMT-LIBv2](http://www.smtlib.org) format.
-2.  `--min-query-time-to-log=TIME` (in ms) is used to log only queries that exceed a certain time limit. **TIME** can be:
-    - **0** (default): to log all queries
-    - **&lt;0**: a negative value specifies that only queries that timed out should be logged. The timeout value is specified via the `--max-solver-time` option.
-    - **&gt;0**: only queries that took more that **TIME** milliseconds should be logged.
-3. `--log-partial-queries-early=true` is used to dump the query to the log file before the next part of the solver chain is called.  Normally, KLEE prints the query and its solution after it has been solved. But if KLEE crashes inside the solver chain, the suspicious query will not be logged. Enable this option to debug such cases. This option comes with a performance penalty as the log buffer gets always flushed.
-4. `--compress-query-log` is used to compress query log files (**default=off**)
+To log the queries issued by KLEE during symbolic execution see [Solver Chain]({{site.baseurl}}/docs/solver-chain/).
 
 ## Entry Point
 

--- a/docs/solver-chain.md
+++ b/docs/solver-chain.md
@@ -78,6 +78,17 @@ This solver can be enabled with the `-use-independent-solver` option.
 
 The remaining solvers are used for debugging.
 
+### Assignment validating solver
+
+This solver checks that assignments to satisfiable queries are satisfiable
+when substituted into the expressions in the query.
+
+This is useful for checking the consistency of KLEE's constraint language and
+that of the core solver.
+
+This option can be enabled using the `-debug-assignment-validating-solver`
+option.
+
 ### Debug validating solver
 
 This solver is meant for debugging and currently is only useful if building with

--- a/docs/solver-chain.md
+++ b/docs/solver-chain.md
@@ -1,0 +1,113 @@
+---
+layout: default
+title: Solver Chain
+subtitle: Overview of solver chain and related command-line options
+slug: solver-chain
+---
+
+{:.toc}
+Contents
+{:.toc__title .no_toc}
+* Table of contents placeholder
+{:.toc__list .list-anchor}
+{:toc}
+
+# The solver chain
+
+KLEE has a number of command line options that control the solver chain that
+is shared both by the `klee` and `kleaver` tools.
+
+The solver chain is implemented internally using the decorator design pattern.
+Thus when a solver query is issued it travels through a nested stack of solvers
+and may eventually call the underlying SMT solver (core solver).
+
+The reasons for this architecture are:
+
+1. Allows transforming the solver query into another form that is hopefully
+   faster for the core solver to solve (e.g. the independence solver).
+2. Allows querying the core solver to be avoided in some cases (e.g. the
+   counterexample caching solver).
+3. Allows logging of queries at different stages in the solver chain.
+
+The `constructSolverChain()` function is used to create the solver chain.
+
+## Core solver
+
+This is the underlying SMT solver. Several solvers are currently supported.
+The default is dependent on what solvers were available when KLEE was built.
+The solver can be selected using the `-solver-backend=` option.
+
+1.  **STP:** Simple Theorem Prover SMT solver [link](http://stp.github.io). Use `-solver-backend=stp`.
+2.  **Z3:** The Z3 Theorem Prover [link](https://github.com/Z3Prover/z3). Use `-solver-backend=z3`.
+3.  **metaSMT:** An Embedded Domain Specific Language for SMT [link](http://www.informatik.uni-bremen.de/agra/eng/metasmt.php). Use `-solver-backend=metasmt`.
+
+When using metaSMT as the core solver, its backend can be specified using the
+`-metasmt-backend=` option.
+
+## Caching Solvers
+
+These solvers cache previous queries to avoid calling the underlying solver when possible.
+
+### Caching solver
+
+This solver caches previous queries and their result to avoid calling the underlying solver
+in certain situations. The queries are canonicalized to increase the cache hit rate.
+
+This solver can be enabled with the `-use-cache` option.
+
+### Counterexample caching solver
+
+This solver caches satisfying assignments to queries (i.e. "counterexamples"
+to validity) which can be used to avoid calling the underlying solver in
+certain situations.
+
+This solver can be enabled with the `-use-cex-cache` option.
+
+<!-- TODO: Explain this solver in greater depth -->
+
+<!-- TODO: Document fastcex solver -->
+
+## Independence solver
+
+This solver splits a query into disjoint sets of independent constraints and
+then calls the underlying solver on each set to solve them independently.
+
+This solver can be enabled with the `-use-independent-solver` option.
+
+## Debugging solvers
+
+The remaining solvers are used for debugging.
+
+### Debug validating solver
+
+This solver is meant for debugging and currently is only useful if building with
+assertions is enabled. The solver can be enabled with the `-debug-validate-solver`
+option.
+
+This solver invokes the underlying solver and a separate solver for every query and
+then checks that the solvers agree. The separate solver can be set with the
+`-debug-crosscheck-core-solver=` option which takes the same arguments as
+`-solver-backend=`.
+
+This is useful for comparing two completly independent solvers (e.g. STP and Z3) and
+for checking that invoking the solver chain and a solver directly obtains the
+same results.
+
+### Query logging solver
+
+The query logging solver logs queries at different positions in the chain.
+
+The option to enable this is the `--use-query-log=` option. The format of the option
+is `--use-query-log=TYPE:FORMAT`, where:
+  - **TYPE** is either **all** to log all the queries given to the solver chain. This is before any optimisation (e.g. caching, constraint independence) is performed, or **solver** to log only the queries passed to the core solver. Note that it is possible that some of the unoptimized queries are never executed or are modified before being executed by KLEE's underlying solver.
+
+  - **FORMAT** is the format in which queries are logged and can be either **kquery** for the [KQuery]({{site.baseurl}}/docs/kquery) format, or **smt2** for the [SMT-LIBv2](http://www.smtlib.org) format.
+
+In addition there are several options that change how these queries are logged.
+
+- `--min-query-time-to-log=TIME` (in ms) is used to log only queries that exceed a certain time limit. **TIME** can be:
+    - **0** (default): to log all queries
+    - **&lt;0**: a negative value specifies that only queries that timed out should be logged. The timeout value is specified via the `--max-solver-time` option.
+    - **&gt;0**: only queries that took more that **TIME** milliseconds should be logged.
+-  `--log-partial-queries-early=true` is used to dump the query to the log file before the next part of the solver chain is called.  Normally, KLEE prints the query and its solution after it has been solved. But if KLEE crashes inside the solver chain, the suspicious query will not be logged. Enable this option to debug such cases. This option comes with a performance penalty as the log buffer gets always flushed.
+-  `--compress-query-log` is used to compress query log files (**default=off**)


### PR DESCRIPTION
This starts to unify the solver options into one document, explains the solver pipeline and also adds the documentation for the assignment validating solver as requested in https://github.com/klee/klee/pull/468