### PR TITLE
Fix publication broken link

### DIFF
--- a/publications.md
+++ b/publications.md
@@ -189,7 +189,7 @@ If you have used or extended KLEE and would like to have your paper listed here,
    International Conference on Software Engineering (ICSE 2015)
    May 16-24, 2015, Florence, Italy
 
-1. [A Framework for Measuring Software Obfuscation Resilience Against Automated Attacks](https://wwwpretschner.in.tum.de/fileadmin/papers/spro15.pdf)
+1. [A Framework for Measuring Software Obfuscation Resilience Against Automated Attacks](https://rawgit.com/alexxnica/publications-clones/master/PID3580639.pdf)
    Sebastian Banescu, Martin Ochoa, Alexander Pretschner
    International Workshop on Software Protection (SPRO 2015)
    May 17, 2015, Florence, Italy


### PR DESCRIPTION
Changes the broken link for *A Framework for Measuring Software Obfuscation Resilience Against Automated Attacks* to a live and working one.
 
``` diff
-https://wwwpretschner.in.tum.de/fileadmin/papers/spro15.pdf
+https://rawgit.com/alexxnica/publications-clones/master/PID3580639.pdf
```