### PR TITLE
Missing statement for including `klee/klee.h` in the first tutorial

### DIFF
--- a/resources/get_sign.c.html
+++ b/resources/get_sign.c.html
@@ -13,6 +13,7 @@
  * First KLEE tutorial: testing a small function
  */</FONT></I>
 
+#<B><FONT COLOR="#5F9EA0">include</FONT></B> <B><FONT COLOR="#BC8F8F">&lt;klee/klee.h&gt;</FONT></B>
 
 <B><FONT COLOR="#228B22">int</FONT></B> <B><FONT COLOR="#0000FF">get_sign</FONT></B>(<B><FONT COLOR="#228B22">int</FONT></B> x) {
   <B><FONT COLOR="#A020F0">if</FONT></B> (x == 0)

--- a/tutorials/testing-function.md
+++ b/tutorials/testing-function.md
@@ -33,6 +33,8 @@ int main() {
 }
 {% endhighlight %}
 
+The function `klee_make_symbolic` is defined in `klee/klee.h`. Therefore, we need to put `#include <klee/klee.h>` in the source code file in order for the compiler to load it.
+
 ## Compiling to LLVM bitcode
 
 KLEE operates on LLVM bitcode. To run a program with KLEE, you first compile it to LLVM bitcode using `clang -emit-llvm`.


### PR DESCRIPTION
If you follow the tutorial exactly, you will get 
```
warning: implicit declaration of function 'klee_make_symbolic' is invalid in C99 [-Wimplicit-function-declaration]
  klee_make_symbolic(&a, sizeof(a), "a");
```
Which is because in both the tutorial content page and the `get_sign.c`, the statement to include `klee/klee.h` is missing.