### PR TITLE
Update llvm 38 instructions, to reflect the PR merged in

### DIFF
--- a/build-llvm38.md
+++ b/build-llvm38.md
@@ -90,25 +90,6 @@ The current procedure for building KLEE with LLVM 3.8 (experimental) is outlined
    ```bash
    $ git clone https://github.com/klee/klee.git
    ```
-    
-   Go into the klee directory:
-   
-   ```bash
-   $ cd klee
-   ```
-
-   Get the relevant pull request:
-
-   ```bash
-   $ git fetch origin pull/900/head:pull900
-   ```
-
-   And merge them in:
-
-   ```bash
-   $ git merge pull900
-   ```
-    
 
 9. **Configure KLEE:**
 


### PR DESCRIPTION
klee/klee#957 showed that our build instructions for llvm38 are a bit out of date. 