### PR TITLE
Typo in KLEE detected to invalid memory accesses

### DIFF
--- a/releases/docs/v1.4.0/tutorials/testing-regex/index.html
+++ b/releases/docs/v1.4.0/tutorials/testing-regex/index.html
@@ -142,7 +142,7 @@ KLEE: <span class="k">done</span>: generated tests <span class="o">=</span> 22</
 
 <p>On startup, KLEE prints the directory used to store output (in this case <code class="highlighter-rouge">klee-out-1</code>). By default klee will use the first free <code class="highlighter-rouge">klee-out-N</code> directory and also create a <code class="highlighter-rouge">klee-last</code> symlink which will point to the most recent created directory. You can specify a directory to use for outputs using the <code class="highlighter-rouge">-output-dir=path</code> command line argument.</p>
 
-<p>While KLEE is running, it will print status messages for “important” events, for example when it finds an error in the program. In this case, KLEE detected to invalid memory accesses on lines 23 and 25 of our test program. We’ll look more at this in a moment.</p>
+<p>While KLEE is running, it will print status messages for “important” events, for example when it finds an error in the program. In this case, KLEE detected two invalid memory accesses on lines 23 and 25 of our test program. We’ll look more at this in a moment.</p>
 
 <p>Finally, when KLEE finishes execution it prints out a few statistics about the run. Here we see that KLEE executed a total of ~6 million instructions, explored 7,692 paths, and generated 22 test cases.</p>
 


### PR DESCRIPTION
Corrected to "KLEE detected two invalid memory accesses"