### PR TITLE
footer: reorder links, update Copyright

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,17 +2,17 @@
   <div class="main-footer__container container clear">
     <div class="main-footer__list-group">
       <ul class="main-footer__list main-footer__list--primary">
-        <li class="sitemap__item sitemap__item--web sitemap__item--home">
-          <strong>Resources</strong>
+        <li class="sitemap__item sitemap__item--github">
+          <a class="sitemap--list__link sitemap--list__link--parent"href="https://github.com/klee">GitHub</a>
         </li>
         <li class="sitemap__item sitemap__item--klee-dev">
           <a class="sitemap--list__link sitemap--list__link--parent"href="{{ site.baseurl }}/klee-dev/">Mailing List</a>
         </li>
+        <li class="sitemap__item sitemap__item--twitter">
+          <a class="sitemap--list__link sitemap--list__link--parent"href="https://twitter.com/kleesymex">Twitter</a>
+        </li>
         <li class="sitemap__item sitemap__item--doxygen">
           <a class="sitemap--list__link sitemap--list__link--parent"href="http://www.doc.ic.ac.uk/~dsl11/klee-doxygen/">Doxygen</a>
-        </li>
-        <li class="sitemap__item sitemap__item--github">
-          <a class="sitemap--list__link sitemap--list__link--parent"href="https://github.com/klee">GitHub</a>
         </li>
         <li class="sitemap__item sitemap__item--buildbot">
           <a class="sitemap--list__link sitemap--list__link--parent"href="https://travis-ci.org/klee/klee/branches">TravisCI</a>
@@ -27,7 +27,7 @@ Documentation for KLEE master branch
 {% endif %}
         </p></div>
         <div  class="g--half g--last">
-         <p style="text-align: right;">&copy; Copyright 2009-2019, The KLEE Team</p>
+         <p style="text-align: right;">&copy; Copyright 2009-2020, The KLEE Team</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
* remove **Resources** in footer
* re-order links
* add link to Twitter
* update Copyright to 2020