### PR TITLE
Fix "build from source" link on home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,8 +32,7 @@ title: KLEE
           </span>
 	  <ol class="list-links list-links--secondary">
 	    <li><a href="{{site.baseurl}}/docker">Run KLEE via Docker</a></li>
-            <li><a
-  href="{{site.baseurl}}/build-llvm60">Build from source (with LLVM 6.0)</a></li>
+            <li><a href="{{site.baseurl}}/build-llvm9/">Build from source (with LLVM 9)</a></li>
             <li><a href="{{site.baseurl}}/docs/options/">Command-line options</a></li>
             <li><a href="{{site.baseurl}}/docs/intrinsics/">Intrinsic functions</a></li>
             <li><a href="{{site.baseurl}}/docs/files/">Generated files</a></li>


### PR DESCRIPTION
The current link (for LLVM 6) gives a 404.