### PR TITLE
Fix 2.2 on release site

### DIFF
--- a/releases/index.md
+++ b/releases/index.md
@@ -7,7 +7,7 @@ slug: releases
 
 | Version         | Date          | Source code      | Docker Image            | Documentation  |
 |:---------------:|:-------------:|:----------------:|:-----------------------:|:--------------:|
-| [2.1][rn2_2]  |   7 Dec 2020 | [git tag][tb2_2] | [`klee/klee:2.2`][di] | [Docs][doc2_2] |
+| [2.2][rn2_2]  |   7 Dec 2020 | [git tag][tb2_2] | [`klee/klee:2.2`][di] | [Docs][doc2_2] |
 | [2.1][rn2_1]  |   3 Mar 2020 | [git tag][tb2_1] | [`klee/klee:2.1`][di] | [Docs][doc2_1] |
 | [2.0][rn2_0]  |  19 Mar 2019 | [git tag][tb2_0] | [`klee/klee:2.0`][di] | [Docs][doc2_0] |
 | [1.4.0][rn1_4]  |  21 Jul 2017 | [git tag][tb1_4] | [`klee/klee:1.4.0`][di] | [Docs][doc1_4] |
@@ -16,6 +16,7 @@ slug: releases
 | [1.1.0][rn1_1]  |  13 Nov 2015  | [git tag][tb1_1] | [`klee/klee:1.1.0`][di] | [Docs][doc1_1] |
 | [1.0.0][rn1_0]  |  10 Aug 2015  | [git tag][tb1_0] | [`klee/klee:1.0.0`][di] | [Docs][doc1_0] |
 
+[rn2_2]: {{site.repository}}/releases/tag/v2.2
 [rn2_1]: {{site.repository}}/releases/tag/v2.1
 [rn2_0]: {{site.repository}}/releases/tag/v2.0
 [rn1_4]: {{site.repository}}/releases/tag/v1.4.0
@@ -24,6 +25,7 @@ slug: releases
 [rn1_1]: {{site.repository}}/releases/tag/v1.1.0
 [rn1_0]: {{site.repository}}/releases/tag/v1.0.0
 
+[doc2_2]: {{site.baseurl}}/releases/docs/v2.2
 [doc2_1]: {{site.baseurl}}/releases/docs/v2.1
 [doc2_0]: {{site.baseurl}}/releases/docs/v2.0
 [doc1_4]: {{site.baseurl}}/releases/docs/v1.4.0
@@ -32,6 +34,7 @@ slug: releases
 [doc1_1]: {{site.baseurl}}/releases/docs/v1.1.0
 [doc1_0]: {{site.baseurl}}/releases/docs/v1.0.0
 
+[tb2_2]: {{site.repository}}/tree/v2.2
 [tb2_1]: {{site.repository}}/tree/v2.1
 [tb2_0]: {{site.repository}}/tree/v2.0
 [tb1_4]: {{site.repository}}/tree/v1.4.0


### PR DESCRIPTION
The entry for release 2.2 of http://klee.github.io/releases/ currently has some broken links, which break the layout.

I copied the structure from the other entries, and this _seemed_ to fix it in github's preview interface.