### PR TITLE
solver installation: link available repos

### DIFF
--- a/build-llvm11.md
+++ b/build-llvm11.md
@@ -56,7 +56,7 @@ KLEE does not work under x86-32.
    KLEE supports multiple different constraint solvers. You must install at least one to build KLEE.
 
    * [STP](https://github.com/stp/stp) Historically KLEE was built around STP so support for this solver is the most stable. For build instructions, see [here]({{site.baseurl}}/build-stp).
-   * [Z3](https://github.com/z3prover/z3) is another solver supported by KLEE that is reasonably stable. You should use Z3 version ≥ 4.4. For build instructions, see [here](https://github.com/Z3Prover/z3/blob/master/README.md).
+   * [Z3](https://github.com/z3prover/z3) is another solver supported by KLEE that is reasonably stable. You should use Z3 version ≥ 4.4. Z3 is packaged by [many distributions](https://repology.org/project/z3/versions). For build instructions, see [here](https://github.com/Z3Prover/z3/blob/master/README.md).
    * [metaSMT](https://github.com/agra-uni-bremen/metaSMT) supports
      various solvers, including Boolector, CVC4, STP, Z3 and Yices.  We recommend branch v4.rc1 (`git clone -b v4.rc1 ...`). For build instructions, see [here](https://github.com/agra-uni-bremen/metaSMT).
 

--- a/build-stp.md
+++ b/build-stp.md
@@ -5,7 +5,9 @@ subtitle: Building STP
 slug: getting-started
 ---
 
-STP is the recommended solver in KLEE.  The instructions below are for release 2.3.3. If you would like to use the upstream version, do not perform the checkout command `git checkout tags/2.3.3` in the instructions below.
+STP is the recommended solver in KLEE. The build instructions below are for release 2.3.3. If you would like to use the upstream version, do not perform the checkout command `git checkout tags/2.3.3` in the instructions below.
+
+Before you attempt to build STP, you should check first if it is not already [supported by your package manager](https://repology.org/project/stp/versions).
 
 STP has a few external dependencies that are first listed here as an install command for Ubuntu 18.04:  
 


### PR DESCRIPTION
STP/Z3 are supported by several distributions. Add a link that users do not attempt to build them if not necessary.