### PR TITLE
rename gen-*bout to ktest-*gen

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -147,7 +147,7 @@ Or if Grafana is running in the foreground then use Ctrl-C.
 The intervals at which KLEE writes its statistics are [configurable]({{site.baseurl}}/docs/options/#statistics).
 All times are lower bounds and a long running solver query might prevent KLEE from writing new entries.
 
-## gen-bout
+## ktest-gen
 
 A tool for generating a `.ktest` [file]({{site.baseurl}}/docs/files) from a concrete input.
 The contents and format of the generated `.ktest` is the same as that described above (similarly, it can be converted into a human-readable form using `ktest-tool`).
@@ -163,11 +163,11 @@ The testcases in the queue can be converted to `.ktest` files so that they can b
 # AFL-generated testcases always begin with 'id:'
 
 find ./queue -not -path '*/\.*' -type f -name 'id:*'    \
-    -exec gen-bout --bout-file {}.ktest --sym-file {} \;
+    -exec ktest-gen --bout-file {}.ktest --sym-file {} \;
 ```
 
 KLEE can subsequently be run with the `-seed-dir` option to seed further exploration.
 
-## gen-random-bout
+## ktest-randgen
 
-Similar to `gen-bout`, except that it generates random data for the `.ktest` file.
+Similar to `ktest-gen`, except that it generates random data for the `.ktest` file.


### PR DESCRIPTION
Incorporate changes from https://github.com/klee/klee/pull/1492.