### PR TITLE
README: add publication list format description

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,22 @@ $ bundle exec jekyll build
 
 Contributions, both to content and design are welcome and encouraged. To contribute, please submit a pull request.
 
+### Contributing to the Publication List
+
+Please open a pull request for missing [publications](https://klee.github.io/publications/) that build upon or use KLEE.
+All list entries are ordered by publication date and follow the layout below:
+
+```markdown
+1. [KLEE: Unassisted and Automatic Generation of High-Coverage Tests for Complex Systems Programs](http://www.doc.ic.ac.uk/~cristic/papers/klee-osdi-08.pdf)⎵⎵
+⎵⎵Cristian Cadar, Daniel Dunbar, Dawson Engler⎵⎵
+⎵⎵USENIX Symposium on Operating Systems Design and Implementation (OSDI 2008)⎵⎵
+⎵⎵December 8-10, 2008, San Diego, CA, USA⎵⎵
+⎵⎵**Klee is available [here](https://klee.github.io/).**
+```
+
+Note that the template language requires that two spaces (shown as `⎵`) are added to every but the last line to insert line-breaks.
+
+
 ## Adding Release Documentation
 
 The repository has old versions of the documentation in `releases/docs/`. To generate documentation for a new release, do the following:


### PR DESCRIPTION
#332 shows that the publication list format is quite odd and one easily can miss the spaces at the end. This PR adds a little documentation to the README.