### PR TITLE
Revert "getting-started: Mention Fedora package"

### DIFF
--- a/getting-started.md
+++ b/getting-started.md
@@ -12,7 +12,6 @@ There are multiple ways to get started with KLEE.
 * [Use your package manager](https://repology.org/project/klee/versions) for Arch Linux, openSUSE Tumbleweed, and several other distributions
 * [Running with Nix]({{site.baseurl}}/nix): this is even faster than Docker if you have Nix.
 * [Build from source against LLVM 11]({{site.baseurl}}/build-llvm11): this is the currently recommended version
-* [Fedora package](https://src.fedoraproject.org/rpms/klee): install the latest release using `dnf install klee`
 * [FreeBSD package](https://www.freshports.org/security/klee): FreeBSD users can install latest release with `pkg install klee` or by building `security/klee` port themselves.
 * [Homebrew package]({{site.baseurl}}/install-brew): install the latest release using [Homebrew](https://brew.sh)
 * [Building arbitrary KLEE configurations]({{site.baseurl}}/build-script): to build different configurations of KLEE and its dependencies


### PR DESCRIPTION
I had to retire the package in Fedora 38 since KLEE is incompatible with LLVM 15 and newer.  I don't have enough skills and time to do the necessary porting work and also motivation since I'm no longer a member of @staticafi. [1]

Unfortunately, no other Fedora packager has volunteered to adopt the package.

This reverts commit 8d877398ebc286ea0fbecf058e78de32fc4ca303.

[1] https://github.com/staticafi