### PR TITLE
Fix: `xfv` instead of `xzfv` in sandbox extraction

### DIFF
--- a/docs/coreutils-experiments.md
+++ b/docs/coreutils-experiments.md
@@ -101,7 +101,7 @@ This document is structured as a series of FAQs:
     3.  Download `sandbox.tgz` by clicking [here](http://www.doc.ic.ac.uk/~cristic/klee/klee-cu-sandbox.html), place it in `/tmp`, and run: 
 
         ```bash
-        $ cd /tmp $ tar xzfv sandbox.tgz
+        $ cd /tmp $ tar xfv sandbox.tgz
         ```
 
 0.  What symbolic arguments did you use in your experiments?


### PR DESCRIPTION
The provided command, `tar xzfv sandbox.tgz`, doesn't work (`gzip: stdin: not in gzip format`), at least for me.