### PR TITLE
Mention Coreutils patches for older and tutorial versions

### DIFF
--- a/tutorials/testing-coreutils.md
+++ b/tutorials/testing-coreutils.md
@@ -13,7 +13,7 @@ All tests were done on a 64-bit Linux machine.
 
 ## Step 1: Build coreutils with gcov
 
-First you will need to download and unpack the source for [coreutils](http://www.gnu.org/software/coreutils/). In this example we use version 6.11 (one version later than what was used for our OSDI paper) but you can use any version of Coreutils. However, for recent versions the `make -C src arch hostname` step can be skipped.
+First you will need to download and unpack the source for [coreutils](http://www.gnu.org/software/coreutils/). In this example we use version 6.11 (one version later than what was used for our OSDI paper) but you can use any version of Coreutils. Note that older versions require patching to work on newer systems - details and instructions can be found [here](https://github.com/coreutils/coreutils/blob/master/scripts/build-older-versions/README.older-versions). Also, for recent versions, the `make -C src arch hostname` step can be skipped.
 
 Before we build with LLVM, let's build a version of _coreutils_ with _gcov_ support. We will use this later to get coverage information on the test cases produced by KLEE.
 


### PR DESCRIPTION
See https://github.com/coreutils/coreutils/blob/master/scripts/build-older-versions/README.older-versions - Coreutils <= 8.29 do not build on newer systems (a patch file must be applied first). Notably, the Coreutils version used in the tutorial does not build for me on Ubuntu 20.04 or 22.04.

Though developers could be expected to find the patch files themselves, it would be nice for the tutorial to be self-contained and mention this. We could potentially even detail the patching but I think that linking the detailed instructions should suffice.