### PR TITLE
remove KLEE Web link on start page

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,6 @@ title: KLEE
             <i class="icon icon-lessons"></i>
           </span>
           <ol class="list-links list-links--secondary">
-            <li><a href="http://klee.doc.ic.ac.uk/">Run small examples in your browser</a></li>
             <li><a href="{{site.baseurl}}/docker">Run KLEE via Docker</a></li>
             <li><a href="{{site.baseurl}}/getting-started/#installation-via-package-manager">Install with your package manager</a></li>
             <li><a href="{{site.baseurl}}/build/build-llvm13/">Build from source (with LLVM 13)</a></li>


### PR DESCRIPTION
Following #392, #395, #396, I would suggest to remove the KLEE Web link from the start page entirely.